### PR TITLE
Add SwiftPM support

### DIFF
--- a/lib/icon_banner/appiconset.rb
+++ b/lib/icon_banner/appiconset.rb
@@ -44,7 +44,7 @@ module IconBanner
     end
 
     def should_ignore_icon(icon)
-      icon[/\/Carthage\//] || icon[/\/Pods\//] || icon[/\/Releases\//]
+      icon[/\/Carthage\//] || icon[/\/Pods\//] || icon[/\/Releases\//] || icon[/\/checkouts\//]
     end
   end
 end


### PR DESCRIPTION
The lib should ignore SPM dependencies as well

Here is an example of an error 
```
Permission denied @ rb_sysopen - swifttpfullpath/checkouts/Dip/SampleApp/DipSampleApp/Assets.xcassets/AppIcon.appiconset/Icon-120.png  
```
@ebelair please review it
